### PR TITLE
bug fix in inference file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 openwebtext_800k.jsonl
-artifacts
-model/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 openwebtext_800k.jsonl
+artifacts
+model/__pycache__

--- a/inference.py
+++ b/inference.py
@@ -53,8 +53,8 @@ if __name__=='__main__':
     template_text = add_chat_format(args.text) if args.model_type == "sft" else args.text
     
     t0 = time.time()
-    start_prompt = torch.tensor(tokenizer.encode(template_text)).unsqueeze(dim=0)
-    eos = torch.tensor([[2]])
+    start_prompt = torch.tensor(tokenizer.encode(template_text)).unsqueeze(dim=0).to(device)
+    eos = torch.tensor([[2]]).to(device)
     print(tokenizer.decode(model.generate(start_prompt, eos).squeeze()))
     t1 = time.time()
 


### PR DESCRIPTION
```
 python inference.py \
> --tokenizer_path ./model/tokenizer \
> --model_path ./artifacts/best_model_15K.pt \
> --text "How many countries are there in world?"
```
ouput
```
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Traceback (most recent call last):
  File "/home/mihir/Desktop/Home/Projects/Open source Projects/lilLM/inference.py", line 58, in <module>
    print(tokenizer.decode(model.generate(start_prompt, eos).squeeze()))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/Desktop/Home/Projects/Open source Projects/lilLM/model/model.py", line 289, in generate
    logits, _ = self(x, start_pos=0, targets=None)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/Desktop/Home/Projects/Open source Projects/lilLM/model/model.py", line 255, in forward
    x = self.tok_emb(x) # (B,T,C)
        ^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/modules/sparse.py", line 190, in forward
    return F.embedding(
           ^^^^^^^^^^^^
  File "/home/mihir/.pyenv/versions/lillm-env/lib/python3.11/site-packages/torch/nn/functional.py", line 2551, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper_CUDA__index_select)
```

after changes 
```
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
Using slow attention
<r0> user<r1> How many countries are there in world?</r2><r0> assistant<r1>.mo.org/vendor/peerwaysyndication.c "https://pointsurance.gaanders.gov/author/me.peng->54807, PLoS One [~18.0 to 1.0][Rav_Day]Jamaica (Note: in the context of EC1, who has to use penalty words, is banned worldwide still and has no orders to reduce executions completely). [~1 Trim cited by Ygushim].Thank you so much for all the content in Ivanney that no one turns up as I've been missing a good bit, you'll see that the new audio for the Starcraft 2 game can be inserted in your json file only if it is sending a nice email to web developer Dr", @bwwaa4Nicholoy5.<|endoftext|> Apple body contents

Ossual component–infected pocket crafted by Fitzroy, France! Armada: Humble?

Apple mic is another Apple Elite Software Alliance company among its 8 maniacs. Companies including Chrome, Chromium, and Yelp have been keeping a close eye on Apple products that exist, and the Sanders group’s goal is to develop industry “think systemic solutions” that tailor an iPhone to users wanting to lose motivation. The CEO, Eric Schneiderman (now Microsoft’s chief financial officer), is coming to what looks like a shorthand to the trend for iPhone property as other direction that Apple have other opportunities to improve and accelerate.

Apple has been building an already underutilized tried-and-true recognition system that was supported in annual OS X releases, and of course, in smartphones recently added layThingsProvide, an easily designed bar-sized screen that focuses on both iPhone cost/core and non-UI, and Apple, a popular handmade card on firehardized Xbox pro computers that go off 400 percent faster than the OnCoC’s 60.2 percent market share. That means Apple’s valuation of $2,018 of market share won applause patches at

 Completed in 5.516591548919678 seconds
 ```